### PR TITLE
Add image ID for Ubuntu Trusty

### DIFF
--- a/data/images.json
+++ b/data/images.json
@@ -3,6 +3,7 @@
   "ubuntu-12.04": "80fbcb55-b206-41f9-9bc2-2dd7aac6c061",
   "ubuntu-13.04": "4b54f5a0-137f-4751-8e7c-fe707185e531",
   "ubuntu-13.10": "df27d481-63a5-40ca-8920-3d132ed643d9",
+  "ubuntu-14.04": "5cc098a5-7286-4b96-b3a2-49f4c4f82537",
   "centos-5.9": "59c037c1-70ec-41e4-aa17-73a9b0cb6b16",
   "centos-5.10": "9522c27d-51d9-44ee-8eb3-fb7b14fd4042",
   "centos-5": "9522c27d-51d9-44ee-8eb3-fb7b14fd4042",


### PR DESCRIPTION
Just noticed this was missing, so thought I'd add it to make life easier for those who want to test on Trusty
