### PR TITLE
Allow timeout to be set

### DIFF
--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -65,6 +65,11 @@ module Kitchen
       required_config :image_id
       required_config :public_key_path
 
+      def initialize(config)
+        Fog.timeout = config[:wait_for].to_i
+        super
+      end
+
       def create(state)
         server = create_server
         state[:server_id] = server.id

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -86,6 +86,10 @@ describe Kitchen::Driver::Rackspace do
       it 'defaults to API key from $RACKSPACE_API_KEY' do
         expect(driver[:rackspace_api_key]).to eq('key')
       end
+
+      it 'defaults to wait_for timeout of 600 seconds' do
+        expect(driver[:wait_for]).to eq(600)
+      end
     end
 
     platforms = {
@@ -125,6 +129,10 @@ describe Kitchen::Driver::Rackspace do
           expect(driver[key]).to eq(value)
         end
       end
+
+      it 'sets the new wait_for variable' do
+        expect(Fog.timeout).to eq(1200)
+      end
     end
 
     context 'OpenStack environment variables' do
@@ -151,6 +159,7 @@ describe Kitchen::Driver::Rackspace do
              public_ip_address: '1.2.3.4')
     end
     let(:driver) do
+      config[:wait_for] = '1200'
       d = Kitchen::Driver::Rackspace.new(config)
       d.instance = instance
       d.stub(:default_name).and_return('a_monkey!')
@@ -163,7 +172,8 @@ describe Kitchen::Driver::Rackspace do
       let(:config) do
         {
           rackspace_username: 'hello',
-          rackspace_api_key: 'world'
+          rackspace_api_key: 'world',
+          wait_for: 1200
         }
       end
 


### PR DESCRIPTION
We've been having trouble with Rackspace being a little slow to set up nodes, so I've had a crack at allowing a `wait_for` variable to be set in the `.kitchen.yml` file, which should help matters.
