### PR TITLE
Some documentation clarification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ for your specified platform. Additional, optional overrides can be provided:
     public_key_path: [PATH TO YOUR PUBLIC SSH KEY]
     rackspace_region: [A VALID RACKSPACE DC/REGION]
     wait_for: [NUM OF SECONDS TO WAIT BEFORE TIMING OUT, DEFAULT 600]
-    no_ssh_tcp_check: [DEFAULTS TO false, SKIPS TCP CHECK WHEN true]
-    ssh_sleep: [NUM OF SECONDS TO SLEEP IF no_ssh_tcp_check IS SET]
 
 You also have the option of providing some configs via environment variables:
 


### PR DESCRIPTION
I got bit by the expectation of a particular file in .ssh (I have multiple keys, but none are named using the default). This commit just clarifies that in the docs, and adjusts the formatting on the omnibus setting to match the other two (the parenthesis is broken, but not obviously something to replace on the omnibus line).
