### PR TITLE
Add two new configuration options, RE: TCP checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ for your specified platform. Additional, optional overrides can be provided:
     public_key_path: [PATH TO YOUR PUBLIC SSH KEY]
     rackspace_region: [A VALID RACKSPACE DC/REGION]
     wait_for: [NUM OF SECONDS TO WAIT BEFORE TIMING OUT, DEFAULT 600]
+    no_ssh_tcp_check: [DEFAULTS TO false, SKIPS TCP CHECK WHEN true]
+    no_ssh_tcp_check_sleep: [NUM OF SECONDS TO SLEEP IF no_ssh_tcp_check IS SET]
 
 You also have the option of providing some configs via environment variables:
 


### PR DESCRIPTION
This commit adds two additional configuration items:

```
+      default_config :ssh_sleep, 120
+      default_config :no_ssh_tcp_check, false
```

If `no_ssh_tcp_check` is true, `wait_for_sshd(state[:hostname])` will be skipped after sleeping for `ssh_sleep` seconds (default sleep of 2 minutes). These changes are required until test-kitchen can read complete SSH configurations, including any proxies or other overrides.

Exposing this new option isn't specific to Rackspace. These settings have been added to control a behavior in kitchen-rackspace (calling a method in test-kitchen that performs a TCP check) that otherwise has no way for the user to control. While that method should probably be removed/fixed from test-kitchen (or made to actually test SSH functionality rather than TCP connectivity), it's actually kitchen-rackspace that is calling it (and should at least allow an override for the behavior). And it's broken for everyone who requires any kind of SSH bastion or proxy command.
