### PR TITLE
Pass :no_passwd_lock to fog

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ for your specified platform. Additional, optional overrides can be provided:
     no_ssh_tcp_check_sleep: [NUM OF SECONDS TO SLEEP IF no_ssh_tcp_check IS SET]
     networks: [LIST OF RACKSPACE NETWORK UUIDS, DEFAULT PUBLICNET AND SERVICE NET]
     rackconnect_wait: ['true' IF USING RACKCONNECT TO WAIT FOR IT TO COMPLETE]
+    no_passwd_lock: ['true' IF FOG LIBRARY SHOULD NOT LOCK ROOT ACCOUNT]
     servicenet: ['true' IF USING THE SERVICENET IP ADDRESS TO CONNECT]
 
 You also have the option of providing some configs via environment variables:

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -39,8 +39,8 @@ module Kitchen
       default_config :rackconnect_wait, false
       default_config :no_passwd_lock, false
       default_config :servicenet, false
-      default_config(:image_id) { |driver| driver.default_image }
-      default_config(:server_name) { |driver| driver.default_name }
+      default_config(:image_id, &:default_image)
+      default_config(:server_name, &:default_name)
       default_config :networks, nil
 
       default_config :public_key_path do

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -37,6 +37,7 @@ module Kitchen
       default_config :no_ssh_tcp_check, false
       default_config :no_ssh_tcp_check_sleep, 120
       default_config :rackconnect_wait, false
+      default_config :no_passwd_lock, false
       default_config :servicenet, false
       default_config(:image_id) { |driver| driver.default_image }
       default_config(:server_name) { |driver| driver.default_name }
@@ -127,7 +128,7 @@ module Kitchen
 
       def create_server
         server_def = { name: config[:server_name], networks: networks }
-        [:image_id, :flavor_id, :public_key_path].each do |opt|
+        [:image_id, :flavor_id, :public_key_path, :no_passwd_lock].each do |opt|
           server_def[opt] = config[opt]
         end
         # see @note on bootstrap def about rackconnect

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -100,6 +100,10 @@ describe Kitchen::Driver::Rackspace do
       it 'defaults to the public ip address' do
         expect(driver[:servicenet]).to eq(false)
       end
+
+      it 'defaults to no_passwd_lock as false' do
+        expect(driver[:no_passwd_lock]).to eq(false)
+      end
     end
 
     platforms = {

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -433,6 +433,7 @@ describe Kitchen::Driver::Rackspace do
         image_id: 'there',
         flavor_id: 'captain',
         public_key_path: 'tarpals',
+        no_passwd_lock: false,
         networks: default_networks
       }
     end


### PR DESCRIPTION
Hey @RoboticCheese -- hope you're doing well! 

This adds support for passing through the `:no_passwd_lock` option to Fog. This stops the bootstrap method from running `passwd -l root` on new servers.

It feels a little bad to not write a unit test, but it's just passing the value verbatim to fog. There isn't even a way to fetch the value from the driver class to be sure it defaults to the correct one.

Fixes #55.