### PR TITLE
Add wait option for Managed Service Level

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
-# Allow additional lines until main driver class can be split 
+# Allow additional lines until main driver class can be split
 # into smaller classes.
 
 ClassLength:
-  Max: 120
+  Max: 125
 AbcSize:
-  Max: 17
+  Max: 20
+MethodLength:
+  Max: 15

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ for your specified platform. Additional, optional overrides can be provided:
     no_ssh_tcp_check_sleep: [NUM OF SECONDS TO SLEEP IF no_ssh_tcp_check IS SET]
     networks: [LIST OF RACKSPACE NETWORK UUIDS, DEFAULT PUBLICNET AND SERVICE NET]
     rackconnect_wait: ['true' IF USING RACKCONNECT TO WAIT FOR IT TO COMPLETE]
+    servicelevel_wait: ['true' IF USING MANAGED SERVICE LEVEL AUTOMATION TO WAIT FOR IT TO COMPLETE]
     servicenet: ['true' IF USING THE SERVICENET IP ADDRESS TO CONNECT]
 
 You also have the option of providing some configs via environment variables:

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -39,8 +39,8 @@ module Kitchen
       default_config :rackconnect_wait, false
       default_config :servicelevel_wait, false
       default_config :servicenet, false
-      default_config(:image_id) { |driver| driver.default_image }
-      default_config(:server_name) { |driver| driver.default_name }
+      default_config(:image_id, &:default_image)
+      default_config(:server_name, &:default_name)
       default_config :networks, nil
 
       default_config :public_key_path do

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -133,7 +133,8 @@ module Kitchen
           server_def[opt] = config[opt]
         end
         # see @note on bootstrap def about rackconnect
-        server_def[:no_passwd_lock] = true if config[:rackconnect_wait] || config[:servicelevel_wait]
+        no_passwd_lock = config[:rackconnect_wait] || config[:servicelevel_wait]
+        server_def[:no_passwd_lock] = no_passwd_lock if no_passwd_lock
         compute.servers.bootstrap(server_def)
       end
 

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -353,7 +353,6 @@ describe Kitchen::Driver::Rackspace do
     end
   end
 
-
   describe '#create and use_private_ip_address' do
     let(:server) do
       double(id: 'test123',


### PR DESCRIPTION
Add the ability to wait for automation that runs on Managed Service Level Rackspace accounts.

Similar to the functionality in knife:
  https://github.com/chef/knife-rackspace/pull/42

Fixes #54.