### PR TITLE
Drop the Ruby 1.9 CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
+  - ruby-head


### PR DESCRIPTION
As seen in #57, fog now depends on fog-google, which depends on Ruby 2.x. As with Test Kitchen itself, we'll try to maintain compatibility with 1.9 as long as possible, but no longer build against it in Travis.