### PR TITLE
Add support for user_data and config_drive options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 # into smaller classes.
 
 ClassLength:
-  Max: 125
+  Max: 130
 AbcSize:
   Max: 20
 MethodLength:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ for your specified platform. Additional, optional overrides can be provided:
     servicelevel_wait: ['true' IF USING MANAGED SERVICE LEVEL AUTOMATION TO WAIT FOR IT TO COMPLETE]
     no_passwd_lock: ['true' IF FOG LIBRARY SHOULD NOT LOCK ROOT ACCOUNT]
     servicenet: ['true' IF USING THE SERVICENET IP ADDRESS TO CONNECT]
+    config_drive: [DEFAULTS TO true, ENABLES READ-ONLY METADATA DRIVE]
+    user_data: [EXTRA CONFIGURATION DATA FOR THE SERVER]
 
 You also have the option of providing some configs via environment variables:
 

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -43,6 +43,8 @@ module Kitchen
       default_config(:image_id, &:default_image)
       default_config(:server_name, &:default_name)
       default_config :networks, nil
+      default_config :user_data, nil
+      default_config :config_drive, true
 
       default_config :public_key_path do
         [
@@ -130,7 +132,8 @@ module Kitchen
 
       def create_server
         server_def = { name: config[:server_name], networks: networks }
-        [:image_id, :flavor_id, :public_key_path, :no_passwd_lock].each do |opt|
+        [:image_id, :flavor_id, :public_key_path,
+         :no_passwd_lock, :user_data, :config_drive].each do |opt|
           server_def[opt] = config[opt]
         end
         # see @note on bootstrap def about rackconnect

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -500,7 +500,9 @@ describe Kitchen::Driver::Rackspace do
         flavor_id: 'captain',
         public_key_path: 'tarpals',
         no_passwd_lock: false,
-        networks: default_networks
+        networks: default_networks,
+        user_data: nil,
+        config_drive: false
       }
     end
     before(:each) do


### PR DESCRIPTION
Adds support for specifying custom user-data. Useful for performing bootstrapping steps on the instance prior to converging. Also enables the read-only config drive by default, which cloud-init needs to find user-data.
