### PR TITLE
Add support for setting region via ENV

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 # into smaller classes.
 
 ClassLength:
-  Max: 125
+  Max: 131
 AbcSize:
   Max: 20
 MethodLength:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You also have the option of providing some configs via environment variables:
 
     export RACKSPACE_USERNAME="user"   # (or OS_USERNAME)
     export RACKSPACE_API_KEY="api_key" # (or OS_PASSWORD)
+    export RACKSPACE_REGION="dfw"      # (or OS_REGION_NAME)
 
 Some configs are also derived based on your .ssh directory, specifically the
 `public_key_path` setting is derived by searching for:

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -32,7 +32,6 @@ module Kitchen
       default_config :flavor_id, 'performance1-1'
       default_config :username, 'root'
       default_config :port, '22'
-      default_config :rackspace_region, 'dfw'
       default_config :wait_for, 600
       default_config :no_ssh_tcp_check, false
       default_config :no_ssh_tcp_check_sleep, 120
@@ -59,6 +58,10 @@ module Kitchen
 
       default_config :rackspace_api_key do
         ENV['RACKSPACE_API_KEY'] || ENV['OS_PASSWORD']
+      end
+
+      default_config :rackspace_region do
+        ENV['RACKSPACE_REGION'] || ENV['OS_REGION_NAME'] || 'dfw'
       end
 
       required_config :rackspace_username

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -160,8 +160,10 @@ describe Kitchen::Driver::Rackspace do
       before(:each) do
         ENV.delete('RACKSPACE_USERNAME')
         ENV.delete('RACKSPACE_API_KEY')
+        ENV.delete('RACKSPACE_REGION')
         ENV['OS_USERNAME'] = 'os_user'
         ENV['OS_PASSWORD'] = 'os_pass'
+        ENV['OS_REGION_NAME'] = 'os_region'
       end
 
       it 'gets to username from $OS_USERNAME' do
@@ -170,6 +172,10 @@ describe Kitchen::Driver::Rackspace do
 
       it 'gets to API key from $OS_PASSWORD' do
         expect(driver[:rackspace_api_key]).to eq('os_pass')
+      end
+
+      it 'gets to region from $OS_REGION_NAME' do
+        expect(driver[:rackspace_region]).to eq('os_region')
       end
     end
   end


### PR DESCRIPTION
Allows for the Rackspace region to be set using the environment
variable `RACKSPACE_REGION` or `OS_REGION_NAME`.
