### PR TITLE
Support booting from a custom private network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,19 @@ for your specified platform. Additional, optional overrides can be provided:
     wait_for: [NUM OF SECONDS TO WAIT BEFORE TIMING OUT, DEFAULT 600]
     no_ssh_tcp_check: [DEFAULTS TO false, SKIPS TCP CHECK WHEN true]
     no_ssh_tcp_check_sleep: [NUM OF SECONDS TO SLEEP IF no_ssh_tcp_check IS SET]
-    networks: [LIST OF RACKSPACE NETWORK UUIDS, DEFAULT PUBLICNET AND SERVICE NET]
+    additional_networks: [LIST OF RACKSPACE NETWORK UUIDS, BESIDES PUBLICNET AND SERVICE NET]
     rackconnect_wait: ['true' IF USING RACKCONNECT TO WAIT FOR IT TO COMPLETE]
     servicelevel_wait: ['true' IF USING MANAGED SERVICE LEVEL AUTOMATION TO WAIT FOR IT TO COMPLETE]
     no_passwd_lock: ['true' IF FOG LIBRARY SHOULD NOT LOCK ROOT ACCOUNT]
-    servicenet: ['true' IF USING THE SERVICENET IP ADDRESS TO CONNECT]
+    servicenet: ['true' IF THE SERVICENET IP ADDRESS SHOULD BE USED TO CONNECT]
+    ssh_network_name: [IF SET, WILL USE THE SPECIFIED NETWORK TO CONNECT]
+    connect_public_net: [DEFAULTS TO true, SET TO false TO PROVISION NO PUBLIC IP]
+
+Specifying ssh_network_name doesn't make sense unless you also provide at least
+one value for additional_networks. While additional_networks takes the 
+Rackspace network uuid, ssh_network_name needs the name that corresponds to
+that uuid.
+
 
 You also have the option of providing some configs via environment variables:
 


### PR DESCRIPTION
I needed to be able to boot instances that don't connect to the public network, and instead have only the service net and a custom private network.

Backwards compatibility broken because I renamed the `:networks` option to `:additional_networks`, since the behavior as it stands is to append the public net and service net to what you specify, which was a little confusing and frustrating when I tried to use the option before looking at the source code.

In order to correctly set the networks, I had to switch from using servers.bootstrap to 
servers.new, server.save, server.setup, and server.update.  Based this on the implementation in the knife-rackspace plugin, which already works the way I needed when you specify the --no-default-networks flag.