### PR TITLE
add ability to specify network for connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ for your specified platform. Additional, optional overrides can be provided:
     servicelevel_wait: ['true' IF USING MANAGED SERVICE LEVEL AUTOMATION TO WAIT FOR IT TO COMPLETE]
     no_passwd_lock: ['true' IF FOG LIBRARY SHOULD NOT LOCK ROOT ACCOUNT]
     servicenet: ['true' IF USING THE SERVICENET IP ADDRESS TO CONNECT]
+    rackspace_newtork: [ DEFAULTS TO '00000000-0000-0000-0000-000000000000' IF servicenet == false WILL USE IP FROM SPECIFIED NETWORK TO CONNECT]
 
 You also have the option of providing some configs via environment variables:
 


### PR DESCRIPTION
Its like [this](https://github.com/test-kitchen/kitchen-rackspace/pull/69) but should be backward compatible. Part of code was used from kitchen-openstack driver. 

P.S. Rubocop makes me crazy :) 