### PR TITLE
Drop Ruby 1.9/2.0 support and get the build green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.3.3
-  - 2.4.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# Encoding: UTF-8
-
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kitchen-rackspace.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# Encoding: UTF-8
-
 require 'bundler/setup'
 require 'rubocop/rake_task'
 require 'rspec/core/rake_task'

--- a/helpers/dump_image_list.rb
+++ b/helpers/dump_image_list.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # Encoding: UTF-8
 
-require 'fog'
+require 'fog/rackspace'
 require 'json'
 
 def whole?(x)

--- a/helpers/dump_image_list.rb
+++ b/helpers/dump_image_list.rb
@@ -1,10 +1,8 @@
 #!/usr/bin/env ruby
-# Encoding: UTF-8
-
 require 'fog/rackspace'
 require 'json'
 
-def whole?(x)
+def whole?(x) # rubocop:disable Naming/UncommunicativeMethodParamName
   (x - x.floor) < 1e-6
 end
 
@@ -56,7 +54,7 @@ res = aliases.each_with_object({}) do |a, hsh|
   hsh
 end
 
-compute.images.select { |i| i_care_about.keys.include?(i.name) }.each do |img|
+compute.images.select { |i| i_care_about.key?(i.name) }.each do |img|
   image_metadata = img.metadata
 
   if image_metadata['org.openstack__1__os_distro'] &&
@@ -75,18 +73,14 @@ compute.images.select { |i| i_care_about.keys.include?(i.name) }.each do |img|
 
     # if it's a whole number non-zero version, also add
     # a dot-zero (centos-7 vs centos-7.0)
-    if version != '0' && version =~ /^\s*\d+\s*$/
-      res["#{distro}-#{version}.0"] = img.id
-    end
+    res["#{distro}-#{version}.0"] = img.id if version != '0' && version =~ /^\s*\d+\s*$/
   end
 
   i_care_about[img.name].each { |a| res[a] = img.id }
   i_care_about.delete(img.name)
 end
 
-unless i_care_about.empty?
-  raise "Couldn't find some images we expected: #{i_care_about.keys}"
-end
+raise "Couldn't find some images we expected: #{i_care_about.keys}" unless i_care_about.empty?
 
 # sort these to make them pretty
 puts JSON.pretty_generate(res.sort.to_h)

--- a/kitchen-rackspace.gemspec
+++ b/kitchen-rackspace.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency 'test-kitchen', '~> 1.1'
   spec.add_dependency 'fog-rackspace', '~> 0.1'

--- a/kitchen-rackspace.gemspec
+++ b/kitchen-rackspace.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'test-kitchen', '~> 1.1'
-  spec.add_dependency 'fog', '~> 1.18'
+  spec.add_dependency 'fog-rackspace', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/kitchen-rackspace.gemspec
+++ b/kitchen-rackspace.gemspec
@@ -1,6 +1,4 @@
-# Encoding: UTF-8
-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kitchen/driver/rackspace_version'
 
@@ -21,14 +19,14 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'test-kitchen', '~> 1.1'
   spec.add_dependency 'fog-rackspace', '~> 0.1'
+  spec.add_dependency 'test-kitchen', '~> 1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.29'
+  spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '~> 0.57.2'
   spec.add_development_dependency 'simplecov', '~> 0.9'
   spec.add_development_dependency 'simplecov-console', '~> 0.2'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
 end

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 require 'benchmark'
-require 'fog'
+require 'fog/rackspace'
 require 'kitchen'
 require 'etc'
 require 'socket'

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -1,5 +1,3 @@
-# Encoding: UTF-8
-
 #
 # Author:: Jonathan Hartman (<j@p4nt5.com>)
 #
@@ -147,7 +145,7 @@ module Kitchen
 
       def images
         @images ||= begin
-          json_file = File.expand_path('../../../../data/images.json', __FILE__)
+          json_file = File.expand_path('../../../data/images.json', __dir__)
           JSON.parse(IO.read(json_file))
         end
       end

--- a/lib/kitchen/driver/rackspace_version.rb
+++ b/lib/kitchen/driver/rackspace_version.rb
@@ -1,4 +1,3 @@
-# Encoding: UTF-8
 # frozen_string_literal: true
 
 #

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -1,5 +1,3 @@
-# Encoding: UTF-8
-
 require_relative '../../spec_helper'
 require_relative '../../../lib/kitchen/driver/rackspace'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# Encoding: UTF-8
-
 require 'rspec'
 require 'simplecov'
 require 'simplecov-console'


### PR DESCRIPTION
Even 2.1 is end of life at this point, but 1.9 and 2.0 are causing rubocop warnings. This also auto ncorrects all the warnings and pins rubocop to prevent random failures in the future.