### PR TITLE
Optimize our requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ servers might fail the TCP; via [@martinb3][]
 
 * PR [#23][] - Switch to PVHVM images, where available
 * PR [#22][] - Update all the images with new IDs
-* PR [#21][] - Add Ubunutu 14.04 to the list of known images; via [@pezholio][]
+* PR [#21][] - Add Ubuntu 14.04 to the list of known images; via [@pezholio][]
 
 # 0.4.0 / 2014-01-27
 

--- a/helpers/dump_image_list.rb
+++ b/helpers/dump_image_list.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'fog/rackspace'
-require 'json'
+require 'json' unless defined?(JSON)
 
 def whole?(x) # rubocop:disable Naming/UncommunicativeMethodParamName
   (x - x.floor) < 1e-6

--- a/lib/kitchen/driver/rackspace.rb
+++ b/lib/kitchen/driver/rackspace.rb
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'benchmark'
+require 'benchmark' unless defined?(Benchmark)
 require 'fog/rackspace'
 require 'kitchen'
-require 'etc'
-require 'socket'
+require 'etc' unless defined?(Etc)
+require 'socket' unless defined?(Socket)
 
 module Kitchen
   module Driver

--- a/spec/kitchen/driver/rackspace_spec.rb
+++ b/spec/kitchen/driver/rackspace_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_relative '../../../lib/kitchen/driver/rackspace'
 
 require 'logger'
-require 'stringio'
+require 'stringio' unless defined?(StringIO)
 require 'rspec'
 require 'kitchen'
 


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>